### PR TITLE
Update required version of Pillow to 7.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 install_requires = ['numpy==1.16',
                     'scipy==1.1.0',
                     'matplotlib==2.2.3',
-                    'pillow==5.3.0',
+                    'pillow==7.1.0',
                     'seaborn==0.9.0',
                     'xlsxwriter >= 0.8.4',
                     'pathlib2',


### PR DESCRIPTION
PR to address alert from Dependabot about vulnerabilities in Pillow 5.3.0, by updating this dependency to version 7.1.0 in `setup.py`.