### PR TITLE
Update to Pillow 8.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 install_requires = ['numpy==1.16',
                     'scipy==1.1.0',
                     'matplotlib==2.2.3',
-                    'pillow==7.1.0',
+                    'pillow==8.1.1',
                     'seaborn==0.9.0',
                     'xlsxwriter >= 0.8.4',
                     'pathlib2',


### PR DESCRIPTION
PR which bumps the required version of the `pillow` dependency to version 8.1.1, to eliminate security vulnerabilities detected in earlier versions.