### PR TITLE
Updates/fixes to PEGS for distribution via PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "Programming Language :: Python :: 3",
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     test_suite='nose.collector',
     tests_require=['nose'],

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ Setup script to install PEGS (Peak-set Enrichment of Gene-Sets)
 """
 
 from setuptools import setup
+import codecs
+import os.path
 
 # Installation requirements
 install_requires = ['numpy==1.16',
@@ -14,12 +16,26 @@ install_requires = ['numpy==1.16',
                     'pathlib2',
                     'future',]
 
-##download_url = 'https://github.com/NAME/pegs/archive/v' + version + 'tar.gz'
+# Acquire package version for installation
+# (see https://packaging.python.org/guides/single-sourcing-package-version/)
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
 
-import pegs
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+PEGS_VERSION = get_version("pegs/__init__.py")
+
 setup(
     name = "pegs",
-    version = pegs.get_version(),
+    version = PEGS_VERSION,
     description = "Peak-set Enrichment of Gene-Sets (PEGS)",
     long_description = "PEGS is a Python bioinformatics utility for " \
     "calculating enrichments of gene cluster enrichments from peak data " \
@@ -53,7 +69,7 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     install_requires = install_requires,
-    data_files = [ ('pegs-%s' % pegs.get_version(),
+    data_files = [ ('pegs-%s' % PEGS_VERSION,
                     ['data/refGene_hg38_120719_intervals.bed',
                      'data/refGene_mm10_120719_intervals.bed',]),],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     "calculating enrichments of gene cluster enrichments from peak data " \
     "at different genomic distances",
     url = 'https://github.com/fls-bioinformatics-core/pegs',
-    ##download_url = download_url,
     author = 'Mudassar Iqbal, Peter Briggs',
     maintainer = 'Peter Briggs',
     maintainer_email = 'peter.briggs@manchester.ac.uk',


### PR DESCRIPTION
PR which makes some updates to `setup.py` to enable distributions of the package to be built for upload to the Python Package Index (PyPI), including:

* Adding `pyproject.toml` file
* Fixing how the package version is acquired in `setup.py`, to be compatible with `python3 -m build`