### PR TITLE
Fix bug in 'bedtools' auto-installation

### DIFF
--- a/pegs/bedtools.py
+++ b/pegs/bedtools.py
@@ -10,6 +10,7 @@
 
 import os
 import io
+import shutil
 try:
     from urllib.request import urlopen
     from urllib.error import URLError
@@ -111,7 +112,10 @@ def fetch_bedtools(install_dir,create_install_dir=False):
     # Install bedtools
     print("...installing 'bedtools' into %s" % install_dir)
     try:
-        os.rename(tmp_bedtools,os.path.join(install_dir,"bedtools"))
+        # Use copy/remove instead of os.rename as latter can't
+        # move files across different devices
+        shutil.copy(tmp_bedtools,os.path.join(install_dir,"bedtools"))
+        os.remove(tmp_bedtools)
     except Exception as ex:
         # Failed to move to installation directory
         logging.error("Couldn't move 'bedtools' to '%s': %s" %


### PR DESCRIPTION
PR which fixes the bug in issue #27 when the automatic installation of `bedtools` fails (in the `fetch_bedtools` function in `pegs/bedtools.py`) because the `tmp` directory is on a different drive to the user's `home` directory (which `os.rename` can't handle). The fix is to use `shutil.copy` + `os.remove` instead.