### PR TITLE
Populate long description for package from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,30 +23,16 @@ clusters at different genomic distances from peaks.
 Quick Start
 -----------
 
-The recommended way to get started with ``PEGS`` is to download
-the latest version from the "releases" page on GitHub:
+It is recommended to install ``PEGS`` via ``pip`` in a virtualenv,
+for example::
 
-https://github.com/fls-bioinformatics-core/pegs/releases
+    % virtualenv venv.pegs
+    % source venv.pegs/bin/activate
+    % pip install pegs
 
-and create a Python virtual environment, to install the software
-into using the ``pip`` utility.
+This will provide the ``pegs`` and ``mk_pegs_intervals`` programs.
 
-For example: to create and activate a virtual environment called
-``venv.pegs`` using the ``virtualenv`` utility:
-
-::
-
-    virtualenv venv.pegs
-    source venv.pegs/bin/activate
-
-The ``PEGS`` package can then be installed using ``pip``, for
-example:
-
-::
-
-    pip install pegs-0.4.2.tgz
-
-The simplest use of the program is:
+The simplest use of ``PEGS`` is:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,15 @@ PEGS: Peak-set Enrichment of Gene-Sets
 a Python bioinformatics utility for calculating enrichments of gene
 clusters at different genomic distances from peaks.
 
+.. image:: https://readthedocs.org/projects/pegs/badge/?version=latest
+   :target: https://pegs.readthedocs.io/
+
+.. image:: https://badge.fury.io/py/pegs.svg
+   :target: https://pypi.python.org/pypi/pegs/
+
+.. image:: https://github.com/fls-bioinformatics-core/pegs/workflows/Python%20package/badge.svg
+   :target: https://github.com/fls-bioinformatics-core/pegs/actions?query=workflow%3A%22Python+package%22
+
 * Free software: 3-Clause BSD License
 * Documentation: https://pegs.readthedocs.io/en/latest/
 * Code: https://github.com/fls-bioinformatics-core/pegs

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,8 @@ PEGS is licensed under the 3-Clause BSD License.
 Example: Mouse glucocorticoidal dataset
 ---------------------------------------
 
+*Thanks to Louise Hunter for providing this example.*
+
 An example application of ``PEGS`` is the analysis of up- and
 down-regulated glucocorticoidal targets from an RNA-seq study
 of liver samples from mice treated acutely with dexamethasone
@@ -102,11 +104,6 @@ distances up to 500kbp from these peaks, but no evidence of
 down-regulated genes - indicating distinct mechanisms of gene
 activation and repression by glucocorticoids. At the same time,
 there is promoter proximal enrichment for both up-and
-down-regulated genes in the DHSs.
-
-**Acknowledgement**
-
-Thanks to Louise Hunter for providing this example.
 
 **References**
 
@@ -120,3 +117,11 @@ Thanks to Louise Hunter for providing this example.
   **359(6381)**:1274-1277
 * Sobel, J.A. *et al.* (2017) Transcriptional regulatory logic of the
   diurnal cycle in the mouse liver. *PLoS Biol* **15(4)**: e2001069
+
+----------------
+Acknowledgements
+----------------
+
+Thanks to Louise Hunter for providing the mouse glucocorticoidal
+example, and to Kyle Pollina for allowing us to use the ``pegs``
+name on the Python Package Index.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -27,7 +27,7 @@ example:
 
 ::
 
-    pip install pegs-0.4.2.tgz
+    pip install pegs
 
 which will make the ``pegs`` and ``mk_pegs_intervals`` utilities
 available.

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,14 @@ def get_version(rel_path):
 
 PEGS_VERSION = get_version("pegs/__init__.py")
 
+# Get long description from the project README
+readme = read('README.rst')
+
 setup(
     name = "pegs",
     version = PEGS_VERSION,
     description = "Peak-set Enrichment of Gene-Sets (PEGS)",
-    long_description = "PEGS is a Python bioinformatics utility for " \
-    "calculating enrichments of gene cluster enrichments from peak data " \
-    "at different genomic distances",
+    long_description = readme,
     url = 'https://github.com/fls-bioinformatics-core/pegs',
     author = 'Mudassar Iqbal, Peter Briggs',
     maintainer = 'Peter Briggs',


### PR DESCRIPTION
PR which updates the `long_description` parameter in the call to `setup` (in `setup.py`) to populate the content from the `README.txt` file; this should provide more useful content on the package landing page on PyPI.