### PR TITLE
Enable peak and cluster files to be specified explicitly on PEGS command line

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -9,7 +9,7 @@ To run an analysis the basic command line is:
 
 ::
 
-    pegs [options] GENE_INTERVALS PEAKS_DIR CLUSTERS_DIR
+    pegs [options] GENE_INTERVALS --peaks PEAKSET [PEAKSET ...] --genes CLUSTER [CLUSTER ...]
 
 where:
 
@@ -17,11 +17,9 @@ where:
    start sites (TSSs) for all genes; it can either be the
    name of a built-in reference set (for example "mm10"),
    or file with BED interval data
- * ``PEAKS_DIR`` is a directory with input BED files
-   containing the ChIP-seq peaks (or other genomic intervals)
-   data (one peak-set per file)
- * ``CLUSTERS_DIR`` is a directory containing the files
-   defining the gene clusters
+ * ``PEAKSET`` is a BED file containing input ChIP-seq
+   peaks data (or other genomic intervals)
+ * ``CLUSTER`` is a file defing a gene cluster
 
 ``PEGS`` will then calculate the enrichments (p-values and
 counts) using a default set of genomic distances around the
@@ -43,13 +41,13 @@ specified at the end of the command line:
 
 ::
 
-    pegs mm10 ./InputPeaks/ ./Clusters/ [DISTANCE [DISTANCE ...]]
+    pegs mm10 --peaks PEAKSET [PEAKSET ...] --genes CLUSTER [CLUSTER ...] [DISTANCE [DISTANCE ...]]
 
 For example:
 
 ::
 
-    pegs mm10 ./InputPeaks/ ./Clusters/ 1000 2000
+    pegs mm10 --peaks ./InputPeaks/*.bed ./Clusters/*.txt 1000 2000
 
 will calculate enrichments for +/-1KB and +/-2KB from the centre
 of the input peak-set intervals.
@@ -101,3 +99,31 @@ by using the ``-o`` option to specify the location.
 
    The directory specified by ``-o`` will be created if it
    doesn't already exist.
+
+Legacy command line
+===================
+
+Note that it is still possible to specify peaksets and clusters
+using the "legacy" (version 0.5.1 and earlier) command line
+format:
+
+::
+
+   pegs [options] GENE_INTERVALS PEAKS_DIR CLUSTERS_DIR [DISTANCE [DISTANCE ...]]
+
+In this case:
+
+ * ``PEAKS_DIR`` is a directory with input BED files
+   containing the ChIP-seq peaks (or other genomic intervals)
+   data (one peak-set per file)
+ * ``CLUSTERS_DIR`` is a directory containing the files
+   defining the gene clusters
+
+This mode of operation has been kept for backwards-compatibility
+but is deprecated and is likely to be removed in future; it is
+recommended that scripts are modified to replace this with the
+equivalent command line:
+
+::
+
+   pegs [options] GENE_INTERVALS --peaks PEAKS_DIR/* --genes CLUSTERS_DIR/* [DISTANCE [DISTANCE ...]]

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -32,26 +32,43 @@ count data called ``pegs_results.xlsx``.
 The formats and naming conventions for the various files are
 described in :doc:`inputs` and :doc:`outputs`.
 
-Specifying genomic distances
-============================
+.. warning::
+
+   This is a change in version 0.6.0 to the previous way of
+   specifying peaksets and gene cluster via directories, which
+   is no longer supported but can replicated using a command
+   line of the form:
+
+   ::
+
+       pegs [options] GENE_INTERVALS --peaks PEAKS_DIR/* --genes CLUSTERS_DIR/*
+
+
+Specifying genomic distances (``-d``, ``--distances``)
+======================================================
 
 The default set of genomic distances used in the enrichment
 calculations can be overriden with a custom set of intervals
-specified at the end of the command line:
+specified using the ``-d`` or ``--distances`` option:
 
 ::
 
-    pegs mm10 --peaks PEAKSET [PEAKSET ...] --genes CLUSTER [CLUSTER ...] [DISTANCE [DISTANCE ...]]
+    pegs mm10 --peaks PEAKSET [PEAKSET ...] --genes CLUSTER [CLUSTER ...] -d [DISTANCE [DISTANCE ...]]
 
 For example:
 
 ::
 
-    pegs mm10 --peaks ./InputPeaks/*.bed ./Clusters/*.txt 1000 2000
+    pegs mm10 --peaks ./InputPeaks/*.bed ./Clusters/*.txt -d 1000 2000
 
 will calculate enrichments for +/-1KB and +/-2KB from the centre
 of the input peak-set intervals.
 
+.. warning::
+
+   This is a change in version 0.6.0 to the previous way of
+   specifying distances at the end of the command line, which
+   is no longer supported.
 
 Specifying TADs (``-t``, ``--tads``)
 ====================================
@@ -99,31 +116,3 @@ by using the ``-o`` option to specify the location.
 
    The directory specified by ``-o`` will be created if it
    doesn't already exist.
-
-Legacy command line
-===================
-
-Note that it is still possible to specify peaksets and clusters
-using the "legacy" (version 0.5.1 and earlier) command line
-format:
-
-::
-
-   pegs [options] GENE_INTERVALS PEAKS_DIR CLUSTERS_DIR [DISTANCE [DISTANCE ...]]
-
-In this case:
-
- * ``PEAKS_DIR`` is a directory with input BED files
-   containing the ChIP-seq peaks (or other genomic intervals)
-   data (one peak-set per file)
- * ``CLUSTERS_DIR`` is a directory containing the files
-   defining the gene clusters
-
-This mode of operation has been kept for backwards-compatibility
-but is deprecated and is likely to be removed in future; it is
-recommended that scripts are modified to replace this with the
-equivalent command line:
-
-::
-
-   pegs [options] GENE_INTERVALS --peaks PEAKS_DIR/* --genes CLUSTERS_DIR/* [DISTANCE [DISTANCE ...]]

--- a/examples/testing/run_examples.sh
+++ b/examples/testing/run_examples.sh
@@ -246,19 +246,13 @@ cd test-output
 run_test "pegs: initial test data" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
     --expected "pegs_count.tsv pegs_pval.tsv" \
-    --command "pegs $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters --dump-raw-data"
-#
-# pegs specifying input peaks and clusters explicitly
-run_test "pegs: specify input peaks and clusters explicitly" \
-    --must_exist "pegs_heatmap.png pegs_results.xlsx" \
-    --expected "pegs_count.tsv pegs_pval.tsv" \
     --command "pegs $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --dump-raw-data"
 #
 # pegs with TADS
 run_test "pegs: initial test data with TADS" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
     --expected "pegs_count.tsv pegs_tads_count.tsv pegs_pval.tsv pegs_tads_pval.tsv" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters -t $DATA_DIR/tads.txt --dump-raw-data"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt -t $DATA_DIR/tads.txt --dump-raw-data"
 #
 # pegs with built-in gene intervals
 run_test "pegs: using built-in mm10 data" \
@@ -266,7 +260,7 @@ run_test "pegs: using built-in mm10 data" \
     --rename pegs_pval.tsv pegs_mm10_builtin_pval.tsv \
     --expected "pegs_mm10_builtin_count.tsv pegs_mm10_builtin_pval.tsv" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
-    --command "$PEGS mm10 $DATA_DIR/peaksets $DATA_DIR/clusters --dump-raw-data"
+    --command "$PEGS mm10 --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --dump-raw-data"
 #
 # pegs keeping intermediate intersection files
 run_test "pegs: keep intersection files" \
@@ -277,7 +271,7 @@ run_test "pegs: keep intersection files" \
     intersection_beds/Intersection.gene_intervals.peakset1.25000.bed
     intersection_beds/Intersection.gene_intervals.peakset2.25000.bed
     intersection_beds/Intersection.gene_intervals.peakset3.25000.bed" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters 5000,25000 --keep-intersection-files"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt 5000,25000 --keep-intersection-files"
 #
 # pegs keeping intermediate intersection files (including TADS)
 run_test "pegs: keep intersection files (including TADS)" \
@@ -291,39 +285,39 @@ run_test "pegs: keep intersection files (including TADS)" \
     intersection_beds/Intersection.gene_intervals.peakset1.tads.bed
     intersection_beds/Intersection.gene_intervals.peakset2.tads.bed
     intersection_beds/Intersection.gene_intervals.peakset3.tads.bed" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters 5000,25000 -t $DATA_DIR/tads.txt --keep-intersection-files"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt 5000,25000 -t $DATA_DIR/tads.txt --keep-intersection-files"
 #
 # pegs with --name option
 run_test "pegs: specify basename for output files" \
     --must_exist "test_heatmap.png test_results.xlsx test_count.tsv test_pval.tsv" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters --dump-raw-data --name test"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --dump-raw-data --name test"
 #
 # pegs with TADS and --name option
 run_test "pegs: specify basename for output files (with TADS)" \
     --must_exist "test_heatmap.png test_results.xlsx test_count.tsv test_tads_count.tsv test_pval.tsv test_tads_pval.tsv" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters -t $DATA_DIR/tads.txt --dump-raw-data --name test"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt -t $DATA_DIR/tads.txt --dump-raw-data --name test"
 #
 # pegs specifying distances as multiple values
 run_test "pegs: specify distances as multiple values" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
     --expected "pegs_count.tsv pegs_pval.tsv" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters 5000 25000 50000 100000 150000 200000 --dump-raw-data"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt 5000 25000 50000 100000 150000 200000 --dump-raw-data"
 #
 # pegs specifying distances as single comma-separated argument
 run_test "pegs: specify distances as single comma-separated argument" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
     --expected "pegs_count.tsv pegs_pval.tsv" \
-    --command "$PEGS --dump-raw-data $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters 5000,25000,50000,100000,150000,200000"
+    --command "$PEGS --dump-raw-data $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt 5000,25000,50000,100000,150000,200000"
 #
 # pegs specifying custom heatmap palette settings
 run_test "pegs: customise heatmap palette options" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters --heatmap-palette start=2 reverse=True"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --heatmap-palette start=2 reverse=True"
 #
 # pegs specifying non-default heatmap name
 run_test "pegs: specify non-default name for heatmap" \
     --must_exist "my_heatmap.svg pegs_results.xlsx" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters -m my_heatmap.svg"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt -m my_heatmap.svg"
 #
 # pegs specifying non-default heatmap name and image format
 run_test "pegs: specify non-default name and image format for heatmap" \
@@ -333,12 +327,24 @@ run_test "pegs: specify non-default name and image format for heatmap" \
 # pegs specifying non-default heatmap image format
 run_test "pegs: specify non-default image format for heatmap" \
     --must_exist "pegs_heatmap.svg pegs_results.xlsx" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters --format svg"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --format svg"
 #
 # pegs specifying custom color scheme for heatmap
 run_test "pegs: specify alternative colour scheme for heatmap" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters --color seagreen"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --color seagreen"
+#
+# pegs check legacy method for specifying peaks and clusters
+run_test "pegs: check legacy method for specifying peaks and clusters" \
+    --must_exist "pegs_heatmap.png pegs_results.xlsx" \
+    --expected "pegs_count.tsv pegs_pval.tsv" \
+    --command "pegs $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets/ $DATA_DIR/clusters/ --dump-raw-data"
+#
+# pegs check legacy method for specifying inputs, with distances
+run_test "pegs: check legacy method for specifying inputs, with distances" \
+    --must_exist "pegs_heatmap.png pegs_results.xlsx" \
+    --expected "pegs_count.tsv pegs_pval.tsv" \
+    --command "pegs $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets/ $DATA_DIR/clusters/ 5000 25000 50000 100000 150000 200000 --dump-raw-data"
 #
 #  mk_pegs_intervals
 run_test "mk_pegs_intervals" \

--- a/examples/testing/run_examples.sh
+++ b/examples/testing/run_examples.sh
@@ -271,7 +271,7 @@ run_test "pegs: keep intersection files" \
     intersection_beds/Intersection.gene_intervals.peakset1.25000.bed
     intersection_beds/Intersection.gene_intervals.peakset2.25000.bed
     intersection_beds/Intersection.gene_intervals.peakset3.25000.bed" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt 5000,25000 --keep-intersection-files"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --distances 5000 25000 --keep-intersection-files"
 #
 # pegs keeping intermediate intersection files (including TADS)
 run_test "pegs: keep intersection files (including TADS)" \
@@ -285,7 +285,7 @@ run_test "pegs: keep intersection files (including TADS)" \
     intersection_beds/Intersection.gene_intervals.peakset1.tads.bed
     intersection_beds/Intersection.gene_intervals.peakset2.tads.bed
     intersection_beds/Intersection.gene_intervals.peakset3.tads.bed" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt 5000,25000 -t $DATA_DIR/tads.txt --keep-intersection-files"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --distances 5000 25000 -t $DATA_DIR/tads.txt --keep-intersection-files"
 #
 # pegs with --name option
 run_test "pegs: specify basename for output files" \
@@ -301,13 +301,13 @@ run_test "pegs: specify basename for output files (with TADS)" \
 run_test "pegs: specify distances as multiple values" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
     --expected "pegs_count.tsv pegs_pval.tsv" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt 5000 25000 50000 100000 150000 200000 --dump-raw-data"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --distances 5000 25000 50000 100000 150000 200000 --dump-raw-data"
 #
 # pegs specifying distances as single comma-separated argument
 run_test "pegs: specify distances as single comma-separated argument" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
     --expected "pegs_count.tsv pegs_pval.tsv" \
-    --command "$PEGS --dump-raw-data $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt 5000,25000,50000,100000,150000,200000"
+    --command "$PEGS --dump-raw-data $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --distances 5000,25000,50000,100000,150000,200000"
 #
 # pegs specifying custom heatmap palette settings
 run_test "pegs: customise heatmap palette options" \
@@ -322,7 +322,7 @@ run_test "pegs: specify non-default name for heatmap" \
 # pegs specifying non-default heatmap name and image format
 run_test "pegs: specify non-default name and image format for heatmap" \
     --must_exist "my_heatmap.svg pegs_results.xlsx" \
-    --command "$PEGS $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters -m my_heatmap.svg --format svg"
+    --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt -m my_heatmap.svg --format svg"
 #
 # pegs specifying non-default heatmap image format
 run_test "pegs: specify non-default image format for heatmap" \
@@ -333,18 +333,6 @@ run_test "pegs: specify non-default image format for heatmap" \
 run_test "pegs: specify alternative colour scheme for heatmap" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \
     --command "$PEGS $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --color seagreen"
-#
-# pegs check legacy method for specifying peaks and clusters
-run_test "pegs: check legacy method for specifying peaks and clusters" \
-    --must_exist "pegs_heatmap.png pegs_results.xlsx" \
-    --expected "pegs_count.tsv pegs_pval.tsv" \
-    --command "pegs $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets/ $DATA_DIR/clusters/ --dump-raw-data"
-#
-# pegs check legacy method for specifying inputs, with distances
-run_test "pegs: check legacy method for specifying inputs, with distances" \
-    --must_exist "pegs_heatmap.png pegs_results.xlsx" \
-    --expected "pegs_count.tsv pegs_pval.tsv" \
-    --command "pegs $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets/ $DATA_DIR/clusters/ 5000 25000 50000 100000 150000 200000 --dump-raw-data"
 #
 #  mk_pegs_intervals
 run_test "mk_pegs_intervals" \

--- a/examples/testing/run_examples.sh
+++ b/examples/testing/run_examples.sh
@@ -248,6 +248,12 @@ run_test "pegs: initial test data" \
     --expected "pegs_count.tsv pegs_pval.tsv" \
     --command "pegs $DATA_DIR/gene_intervals.bed $DATA_DIR/peaksets $DATA_DIR/clusters --dump-raw-data"
 #
+# pegs specifying input peaks and clusters explicitly
+run_test "pegs: specify input peaks and clusters explicitly" \
+    --must_exist "pegs_heatmap.png pegs_results.xlsx" \
+    --expected "pegs_count.tsv pegs_pval.tsv" \
+    --command "pegs $DATA_DIR/gene_intervals.bed --peaks $DATA_DIR/peaksets/*.bed --genes $DATA_DIR/clusters/*.txt --dump-raw-data"
+#
 # pegs with TADS
 run_test "pegs: initial test data with TADS" \
     --must_exist "pegs_heatmap.png pegs_results.xlsx" \

--- a/pegs/cli.py
+++ b/pegs/cli.py
@@ -20,6 +20,7 @@ from .intervals import make_gene_interval_file
 from .bedtools import fetch_bedtools
 from .bedtools import bedtools_version
 from .utils import find_exe
+from .utils import collect_files
 from . import get_version
 
 # Description
@@ -190,6 +191,16 @@ def pegs():
     except KeyError:
         # Not found, ignore
         pass
+    # Get the peak files
+    peaks = collect_files(args.peaks_dir)
+    if not peaks:
+        logging.fatal("No peaks files found in %s" % args.peaks_dir)
+        return 1
+    # Get the cluster files
+    clusters = collect_files(args.clusters_dir)
+    if not clusters:
+        logging.fatal("No cluster files found in %s" % args.clusters_dir)
+        return 1
     # Check TADs file is actually a file
     if args.tads_file:
        if not os.path.exists(args.tads_file):
@@ -266,8 +277,8 @@ Authors: Mudassar Iqbal, Peter Briggs
     # Calculate the enrichments
     pegs_main(genes_file=gene_interval_file,
               distances=distances,
-              peaks_dir=args.peaks_dir,
-              clusters_dir=args.clusters_dir,
+              peaks=peaks,
+              clusters=clusters,
               tads_file=args.tads_file,
               name=args.name,
               heatmap=args.output_heatmap,

--- a/pegs/cli.py
+++ b/pegs/cli.py
@@ -175,10 +175,29 @@ def pegs():
     # Deal with positional arguments for peak and cluster files
     if args.peaks and args.clusters:
        # Peaks and clusters specified via arguments
-       peaks = sort_files(args.peaks)
-       clusters = sort_files(args.clusters)
+       # Note that trailing peaks or clusters might actually
+       # be distances
+       peaks = list()
+       clusters = list()
+       distances = list()
+       for peakset in args.peaks:
+          if not (peakset.isdigit() or ',' in peakset):
+             # Assume it's a peakset file
+             peaks.append(peakset)
+          else:
+             # Assume it's a distance
+             distances.append(peakset)
+       peaks = sort_files(peaks)
+       for cluster in args.clusters:
+          if not (cluster.isdigit() or ',' in cluster):
+             # Assume it's a peakset file
+             clusters.append(cluster)
+          else:
+             # Assume it's a distance
+             distances.append(cluster)
+       clusters = sort_files(clusters)
        # Remaining arguments must be distances
-       distances = args.args
+       distances = distances.extend(args.args)
     elif not (args.peaks or args.clusters):
        if len(args.args) > 1:
           # First two arguments must be peaks dir and genes dir

--- a/pegs/pegs.py
+++ b/pegs/pegs.py
@@ -34,7 +34,6 @@ from .bedtools import intersect
 from .outputs import make_heatmap
 from .outputs import make_xlsx_file
 from .outputs import write_raw_data
-from .utils import collect_files
 from .utils import count_genes
 from .utils import intersection_file_basename
 
@@ -283,7 +282,7 @@ def calculate_enrichments(genes_file,distances,peaks,clusters,tads_file,
     # Return the enrichment data
     return (pvalues,counts,tads_pvalues,tads_counts)
 
-def pegs_main(genes_file,distances,peaks_dir,clusters_dir,
+def pegs_main(genes_file,distances,peaks,clusters,
               tads_file,name,heatmap=None,xlsx=None,
               output_directory=None,
               keep_intersection_files=False,
@@ -296,9 +295,8 @@ def pegs_main(genes_file,distances,peaks_dir,clusters_dir,
     Arguments:
       genes_file (str): path to BED file with all genes
       distances (list): list of distances to calculate enrichments at
-      peaks_dir (str): path to directory with BED files containing
-        the ChIP-seq peaks
-      clusters_dir (str): path to directory with cluster files
+      peaks (list): list of BED files containing the ChIP-seq peaks
+      clusters (list): list of cluster files
       tads_file (str): path to BED file with TADs
       name (str): basename to use for output files
       heatmap (str): path for output heatmap image file
@@ -325,23 +323,19 @@ def pegs_main(genes_file,distances,peaks_dir,clusters_dir,
                       genes_file)
         return
 
-    # Get the peak files
-    peaks = collect_files(peaks_dir)
+    # Report the peak files
     print("====Peaks Files====")
-    print("Directory: %s"%  peaks_dir)
     if not peaks:
-        logging.fatal("No peaks files found in %s" % peaks_dir)
+        logging.fatal("No peaks files supplied")
         return
     for f in peaks:
         print("%s" % basename(f))
     print("")
 
-    # Get the cluster files
-    clusters = collect_files(clusters_dir)
+    # Report the cluster files
     print("====Cluster Files====")
-    print("Directory: %s" % clusters_dir)
     if not clusters:
-        logging.fatal("No cluster files found in %s" % clusters_dir)
+        logging.fatal("No cluster files supplied")
         return
     for f in clusters:
         print("%s" % basename(f))

--- a/pegs/test/test_pegs.py
+++ b/pegs/test/test_pegs.py
@@ -462,8 +462,8 @@ chr1	136212828	146212829	TAD4
         distances = [5000000,10000000]
         pegs_main(genes_file,
                   distances,
-                  peaks_dir,
-                  cluster_dir,
+                  peaks,
+                  clusters,
                   tads_file,
                   "pegs_test",
                   output_directory=self.test_dir)

--- a/pegs/test/test_utils.py
+++ b/pegs/test/test_utils.py
@@ -8,6 +8,7 @@ import shutil
 from pegs.utils import find_exe
 from pegs.utils import count_genes
 from pegs.utils import collect_files
+from pegs.utils import sort_files
 from pegs.utils import split_file_name_for_sort
 from pegs.utils import intersection_file_basename
 
@@ -94,6 +95,18 @@ class TestCollectFiles(unittest.TestCase):
                 fp.write("4930516B21Rik\n")
         self.assertEqual(collect_files(self.test_dir),
                          cluster_files)
+
+class TestSortFiles(unittest.TestCase):
+    def test_sort_files(self):
+        """
+        sort_files: returns list of files sorted appropriately
+        """
+        self.assertEqual(sort_files(("file3","file1","file2")),
+                         ["file1","file2","file3"])
+        self.assertEqual(sort_files(("file10","file1","file21")),
+                         ["file1","file10","file21"])
+        self.assertEqual(sort_files(("file1_10","file1_1","file2_10")),
+                         ["file1_1","file1_10","file2_10"])
 
 class TestSplitFileNameForSort(unittest.TestCase):
     def test_split_file_name_for_sort(self):

--- a/pegs/utils.py
+++ b/pegs/utils.py
@@ -54,7 +54,8 @@ def collect_files(d):
     """
     return sorted([abspath(join(d,f))
                    for f in listdir(d) if isfile(join(d,f))
-                   and not f.startswith('.')],
+                   and not f.startswith('.')
+                   and not f.endswith('~')],
                   key=split_file_name_for_sort)
 
 def split_file_name_for_sort(f):

--- a/pegs/utils.py
+++ b/pegs/utils.py
@@ -52,11 +52,16 @@ def collect_files(d):
     """
     Collect files from a directory
     """
-    return sorted([abspath(join(d,f))
-                   for f in listdir(d) if isfile(join(d,f))
-                   and not f.startswith('.')
-                   and not f.endswith('~')],
-                  key=split_file_name_for_sort)
+    return sort_files([abspath(join(d,f))
+                       for f in listdir(d) if isfile(join(d,f))
+                       and not f.startswith('.')
+                       and not f.endswith('~')])
+
+def sort_files(f):
+    """
+    Sort files based on integer components
+    """
+    return sorted(f,key=split_file_name_for_sort)
 
 def split_file_name_for_sort(f):
     """


### PR DESCRIPTION
PR to address issue #36 and enable peak and cluster files to specified explicitly on the command line (~as well as implicitly via the directories as before, for backward compatibility~).

In agreement with co-authors, the need for backwards compatibility with earlier versions of PEGS has been dropped. So the changes in the PR are now:

* New compulsory flags `--peaks` and `--genes` are used to specify one or more input peakset and cluster files
* New option `-d`/`--distances` is used to specify distance intervals to override the defaults.