### PR TITLE
Update citation information following final publication on F1000R

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -32,6 +32,6 @@ If you use PEGS in your research then please cite:
 
 *  Briggs P, Hunter AL, Yang Sh et al.
    PEGS: An efficient tool for gene set enrichment within defined
-   sets of genomic intervals [version 1; peer review: 2 approved].
+   sets of genomic intervals [version 2; peer review: 2 approved].
    F1000Research 2021, 10:570
-   (https://doi.org/10.12688/f1000research.53926.1)
+   (https://doi.org/10.12688/f1000research.53926.2)

--- a/pegs/cli.py
+++ b/pegs/cli.py
@@ -33,9 +33,9 @@ If you use PEGS in your research then please cite:
 
 * Briggs P, Hunter AL, Yang Sh et al.
   PEGS: An efficient tool for gene set enrichment within defined
-  sets of genomic intervals [version 1; peer review: 2 approved].
+  sets of genomic intervals [version 2; peer review: 2 approved].
   F1000Research 2021, 10:570
-  (https://doi.org/10.12688/f1000research.53926.1)
+  (https://doi.org/10.12688/f1000research.53926.2)
 """
 
 # Default set of distances for enrichment calculation


### PR DESCRIPTION
PR which updates the information on how to cite `PEGS` following the final publication of the supporting paper on F1000R (https://f1000research.com/articles/10-570/v2).