### PR TITLE
Always force use of non-interactive 'Agg' matplotlib backend for PEGS

### DIFF
--- a/pegs/cli.py
+++ b/pegs/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     cli.py: CLI for gene cluster enrichment analysis
-#     Copyright (C) University of Manchester 2018-2021 Mudassar Iqbal, Peter Briggs
+#     Copyright (C) University of Manchester 2018-2022 Mudassar Iqbal, Peter Briggs
 #
 from builtins import str
 import os
@@ -10,9 +10,7 @@ import logging
 # Deal with matplotlib backend before importing seaborn
 # See https://stackoverflow.com/a/50089385/579925
 import matplotlib
-if os.environ.get('DISPLAY','') == '':
-   print('No display found: using non-interactive Agg backend')
-   matplotlib.use('Agg')
+matplotlib.use('Agg')
 import seaborn as sns
 import pathlib2
 from .pegs import pegs_main

--- a/pegs/outputs.py
+++ b/pegs/outputs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     outputs.py: functions for outputting result data
-#     Copyright (C) University of Manchester 2018-2021 Mudassar Iqbal, Peter Briggs
+#     Copyright (C) University of Manchester 2018-2022 Mudassar Iqbal, Peter Briggs
 #
 
 #######################################################################
@@ -33,9 +33,7 @@ import numpy as np
 # Deal with matplotlib backend
 # See https://stackoverflow.com/a/50089385/579925
 import matplotlib
-if os.environ.get('DISPLAY','') == '':
-   print('No display found: using non-interactive Agg backend')
-   matplotlib.use('Agg')
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import seaborn as sns
 import xlsxwriter


### PR DESCRIPTION
PR which updates the `cli` and `output` modules to force the use of the non-interactive `Agg` `matplotlib` backend, regardless of the setting of the `DISPLAY` environment.

This is intended as a fix to the bug reported in issue #53.