### PR TITLE
Update configuration for building documentation on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+python:
+  install:
+    - requirements: requirements.txt
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==7.1.2
+sphinx_rtd_theme==2.0.0
+readthedocs-sphinx-search==0.3.1


### PR DESCRIPTION
Changes needed to keep building documentation on ReadTheDocs:

* add `.readthedocs.yaml` file
* add `docs/requirements.txt` file