### PR TITLE
Pin 'xlsxwriter' dependency version to 3.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ scipy==1.5.4
 matplotlib==3.3.4
 pillow==8.1.1
 seaborn==0.11.1
-xlsxwriter >= 0.8.4
+xlsxwriter==3.9.1
 pathlib2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = ['numpy==1.19.5',
                     'matplotlib==3.3.4',
                     'pillow==8.1.1',
                     'seaborn==0.11.1',
-                    'xlsxwriter >= 0.8.4',
+                    'xlsxwriter==3.9.1',
                     'pathlib2']
 
 # Acquire package version for installation


### PR DESCRIPTION
Updates the dependencies for `pegs` so that the required version of `xlsxwriter` must be 3.9.1.