### PR TITLE
Pin 'xlsxwriter' dependency version to 3.1.9

### DIFF
--- a/pegs/outputs.py
+++ b/pegs/outputs.py
@@ -292,7 +292,8 @@ def make_xlsx_file(xlsx_file,peaks,clusters,distances,pvalues,counts,
                      for x in clusters]
 
     # Output workbook
-    xlsx_out = xlsxwriter.Workbook(xlsx_file)
+    xlsx_out = xlsxwriter.Workbook(xlsx_file,
+                                   {'constant_memory': True})
 
     # Make separate sheets for each set of values
     ws_common_genes = xlsx_out.add_worksheet("Common Genes")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ scipy==1.5.4
 matplotlib==3.3.4
 pillow==8.1.1
 seaborn==0.11.1
-xlsxwriter >= 0.8.4
+xlsxwriter==3.1.9
 pathlib2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = ['numpy==1.19.5',
                     'matplotlib==3.3.4',
                     'pillow==8.1.1',
                     'seaborn==0.11.1',
-                    'xlsxwriter >= 0.8.4',
+                    'xlsxwriter==3.1.9',
                     'pathlib2']
 
 # Acquire package version for installation


### PR DESCRIPTION
Updates the dependencies for pegs so that the required version of `xlsxwriter` is pinned to 3.1.9 (the current latest version).

Also fixes an error in the `make_xlsx_file` function (in the `outputs` module) whereby the `merge_ranges` method of the `xlsxwriter` `Workbook` class couldn't be invoked more than once for instances created with just the defaults.

The fix is to explicitly create `Workbook` instances with `constant_memory` set to `True` (described in more detail at https://github.com/jmcnamara/XlsxWriter/issues/292).